### PR TITLE
Is checkout page check moved to single

### DIFF
--- a/src/Mollie/WC/Plugin.php
+++ b/src/Mollie/WC/Plugin.php
@@ -240,8 +240,10 @@ class Mollie_WC_Plugin
 		add_action( 'woocommerce_order_status_completed', array( __CLASS__, 'shipAndCaptureOrderAtMollie' ) );
 
         // Enqueue Scripts
-        add_action('wp_enqueue_scripts', [__CLASS__, 'enqueueFrontendScripts']);
-        add_action('wp_enqueue_scripts', [__CLASS__, 'enqueueComponentsAssets']);
+        if (!is_admin() && isCheckoutContext()) {
+            add_action('wp_enqueue_scripts', [__CLASS__, 'enqueueFrontendScripts']);
+            add_action('wp_enqueue_scripts', [__CLASS__, 'enqueueComponentsAssets']);
+        }
 
         add_action(
             Mollie_WC_Payment_OrderItemsRefunder::ACTION_AFTER_REFUND_ORDER_ITEMS,
@@ -361,10 +363,6 @@ class Mollie_WC_Plugin
      */
     public static function enqueueFrontendScripts()
     {
-        if (is_admin() || !isCheckoutContext()) {
-            return;
-        }
-
         wp_enqueue_script('mollie_wc_gateway_applepay');
     }
 
@@ -383,10 +381,6 @@ class Mollie_WC_Plugin
         $gatewayNames = array_keys($mollieComponentsStylesGateways);
 
         if (!$merchantProfileId || !$mollieComponentsStylesGateways) {
-            return;
-        }
-
-        if (is_admin() || !isCheckoutContext()) {
             return;
         }
 


### PR DESCRIPTION
isCheckoutContext function is making DB calls to check if it is a checkout page and decreasing amount of calls will increase the performance of the plugin.

Related issue: https://github.com/mollie/WooCommerce/issues/339